### PR TITLE
InCallUI: Don't force enable the prox sensor for incoming calls

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -69,6 +69,7 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
     ims-ext-common \
     phonebook_wrapper \
     telephony-common \
+    org.cyanogenmod.platform.internal \
     org.cyanogenmod.platform.sdk
 
 LOCAL_PACKAGE_NAME := Dialer

--- a/InCallUI/src/com/android/incallui/ProximitySensor.java
+++ b/InCallUI/src/com/android/incallui/ProximitySensor.java
@@ -31,6 +31,8 @@ import com.android.incallui.AudioModeProvider.AudioModeListener;
 import com.android.incallui.InCallPresenter.InCallState;
 import com.android.incallui.InCallPresenter.InCallStateListener;
 
+import org.cyanogenmod.platform.internal.R;
+
 /**
  * Class manages the proximity sensor for the in-call UI.
  * We enable the proximity sensor while the user in a phone call. The Proximity sensor turns off
@@ -55,6 +57,8 @@ public class ProximitySensor implements AccelerometerListener.OrientationListene
     private boolean mIsPhoneOffhook = false;
     private boolean mDialpadVisible;
     private Context mContext;
+    private boolean mProximityWakeSupported;
+    private int mProximityWakeDefault;
 
     // True if the keyboard is currently *not* hidden
     // Gets updated whenever there is a Configuration change
@@ -80,6 +84,11 @@ public class ProximitySensor implements AccelerometerListener.OrientationListene
 
         mAudioModeProvider = audioModeProvider;
         mAudioModeProvider.addListener(this);
+
+        mProximityWakeSupported = context.getResources().getBoolean(
+                R.bool.config_proximityCheckOnWake);
+        mProximityWakeDefault = context.getResources().getBoolean(
+                R.bool.config_proximityCheckOnWakeEnabledByDefault) ? 1 : 0;
     }
 
     public void tearDown() {
@@ -266,8 +275,9 @@ public class ProximitySensor implements AccelerometerListener.OrientationListene
                     .add("aud", CallAudioState.audioRouteToString(audioMode))
                     .toString());
 
-            final boolean proximityOnWake = CMSettings.System.getInt(mContext.getContentResolver(),
-                    CMSettings.System.PROXIMITY_ON_WAKE, 1) == 1;
+            final boolean proximityOnWake = mProximityWakeSupported &&
+                    CMSettings.System.getInt(mContext.getContentResolver(),
+                            CMSettings.System.PROXIMITY_ON_WAKE, mProximityWakeDefault) == 1;
 
             if ((mIsPhoneOffhook || (mHasIncomingCall && proximityOnWake))
                     && !screenOnImmediately) {


### PR DESCRIPTION
The proximity sensor should be enabled for incoming calls only if the
proximity check on wake feature is enabled. A device with no proximity
check on wake support does not have PROXIMITY_ON_WAKE set, so getInt()
returns the default value (enabled) and we incorrectly enable the
proximity sensor for incoming calls. Check whether the proximity check
on wake feature is supported or not and never enable the proximity
sensor for incoming calls if it isn't.

Also, since there's an overlay to specify the default value for the
proximity check on wake, use that instead of the hard-coded "enabled".

Change-Id: I17598c24d1908107927881fc31a701457094c61e